### PR TITLE
fix SockJSSocket handler_id, return java_obj.writeHandlerID() directly

### DIFF
--- a/src/main/api_shim/core/sock_js.py
+++ b/src/main/api_shim/core/sock_js.py
@@ -97,14 +97,8 @@ class SockJSSocket(core.streams.ReadStream, core.streams.WriteStream):
         self.remote_addr = None
         self.local_addr = None
 
-        def simple_handler(msg):
-            self.write(msg.body)
-
-        self.handler_id = EventBus.register_simple_handler(True, simple_handler)
-
     def close(self):
         """Close the socket"""
-        EventBus.unregister_handler(self.handler_id)
         self.java_obj.close()
 
     def handler_id(self):
@@ -113,7 +107,7 @@ class SockJSSocket(core.streams.ReadStream, core.streams.WriteStream):
         Given this ID, a different event loop can send a buffer to that event handler using the event bus. This
         allows you to write data to other SockJSSockets which are owned by different event loops.
         """
-        return self.handler_id
+        return self.java_obj.writeHandlerID()
         
     @property
     def remote_address(self):


### PR DESCRIPTION
The current SockJSSocket handler_id() code is definitely wrong, as the self.handler_id replaces the handler_id method. I assume there is no reason why not to return java_obj.writeHandlerID() directly, so this patch does that. I also assume the handler_id should be a method and not a property. 

To reproduce the issue

server.py:

``` python
import functools
import vertx
from core.event_bus import EventBus
from core.buffer import Buffer

server = vertx.create_http_server()

@server.request_handler
def request_handler(req):
    file = ''
    if req.path == '/':
        file = 'index.html'
    elif '..' not in req.path:
        file = req.path[1:]
    req.response.send_file(file)

sockJSServer = vertx.create_sockjs_server(server)
bridge = sockJSServer.bridge({'prefix' : '/eventbus'},
    [],
    [])


@bridge.socket_created_handler
def bridge_socket_created_handler(socket):
    print "my socket created, address: " + `socket.handler_id()`
    EventBus.send(socket.handler_id(), Buffer.create_from_str('{"address":"some-address","body":"Hello, world"}'))

server.listen(8080, 'localhost')
```

index.html:

``` html
<!DOCTYPE html>
<html>
<head>
    <title>Hello</title>
    <script src="http://cdn.sockjs.org/sockjs-0.3.4.min.js"></script>
    <script src='vertxbus-2.1.js'></script>
<script>
    var eb = new vertx.EventBus('http://localhost:8080/eventbus');
    eb.onopen = function() {
      eb.registerHandler('some-address', function(message) {
        console.log('received a message: ' + JSON.stringify(message));
      });
    }
</script>
</head>
<body>
</body>
</html>
```
